### PR TITLE
[Lib] Add support for glusterfs-registry sc

### DIFF
--- a/tests/glusterfs-containers-tests-config.yaml
+++ b/tests/glusterfs-containers-tests-config.yaml
@@ -94,6 +94,20 @@ openshift:
                 hacount: "3"
                 chapauthenabled: "true"
                 volumenameprefix: "autotests-block"
+            registry_block_storage_class:
+                chapauthenabled: 'true'
+                hacount: '3'
+                provisioner: gluster.org/glusterblock
+                restsecretnamespace: "<fake-namespace-name>"
+                resturl: "<fake-url>"
+                restuser: "<fake-user>"
+                volumenameprefix: autotests-registry-block
+            registry_file_storage_class:
+                provisioner: kubernetes.io/glusterfs
+                resturl: "<fake-url>"
+                restuser: "<fake-user>"
+                secretnamespace: "<fake-namespace-name>"
+                volumenameprefix: autotests-registry-file
     metrics:
         metrics_project_name: "<metrics-project-name>"
         metrics_rc_hawkular_cassandra: "<hawkular-cassandra-rc-name>"


### PR DESCRIPTION
Changes to create secret and storage class in the glusterfs-registry namespace in base-class.
Also  changes to default glusterfs-containers-tests-config.yaml to include glusterfs-registry storage class parameters.

Signed-off-by: Sri Vignesh <sselvan@redhat.com>