### PR TITLE
[TestFix] Fix  issues for bulk tests execution

### DIFF
--- a/openshift-storage-libs/openshiftstoragelibs/heketi_ops.py
+++ b/openshift-storage-libs/openshiftstoragelibs/heketi_ops.py
@@ -2107,7 +2107,9 @@ def validate_dev_path_vg_and_uuid(
         h_vg = bricks[0]["path"].split("/")[5]
 
     # Collect data from the node
-    cmd = "pvs --noheadings -o vg_name,uuid -S name={}".format(dev_name)
+    cmd = ("pvs --noheadings -o vg_name,uuid "
+           "-S name={}".format(dev_name))
+    cmd = TIMEOUT_PREFIX + cmd
     n_vg, n_uuid = command.cmd_run(cmd, hostname=hostname).split()
 
     # Compare the vg from node and heketi

--- a/openshift-storage-libs/openshiftstoragelibs/openshift_storage_libs.py
+++ b/openshift-storage-libs/openshiftstoragelibs/openshift_storage_libs.py
@@ -254,7 +254,8 @@ def get_pvs_info(node, gluster_node_ip, devices_list, raise_on_error=True):
 
     pvs_info = []
     for device in devices_list:
-        cmd = ("pvs -o pv_name,pv_uuid,vg_name | grep {}".format(device))
+        cmd = ("timeout 120 pvs -o pv_name,pv_uuid,vg_name | "
+               "grep {}".format(device))
         out = cmd_run_on_gluster_pod_or_node(
             node, cmd, gluster_node_ip, raise_on_error=raise_on_error)
         pvs_info.append(out.split())

--- a/tests/functional/arbiter/test_arbiter.py
+++ b/tests/functional/arbiter/test_arbiter.py
@@ -819,7 +819,7 @@ class TestArbiterVolumeCreateExpandDelete(baseclass.BaseClass):
                     openshift_ops.cmd_run_on_gluster_pod_or_node(
                         self.node, cmd, gluster_node_ip)
 
-    @pytest.mark.tier2
+    @pytest.mark.tier4
     def test_arbiter_scaled_heketi_and_gluster_volume_mapping(self):
         """Test to validate PVC, Heketi & gluster volume mapping
         for large no of PVC's

--- a/tests/functional/heketi/test_heketi_lvm_wrapper.py
+++ b/tests/functional/heketi/test_heketi_lvm_wrapper.py
@@ -318,6 +318,9 @@ class TestHeketiLvmWrapper(baseclass.BaseClass):
         server_node = server_info.get('manage')
         additional_device = server_info.get('additional_devices')[0]
 
+        # command to run pvscan
+        cmd_pvscan = "timeout 300 pvscan"
+
         # Get pod name from on host
         for pod_info in self.pod_name:
             if pod_info.get('pod_hostname') == server_node:
@@ -350,8 +353,7 @@ class TestHeketiLvmWrapper(baseclass.BaseClass):
                 self.oc_node, pod_name, "ps aux | grep dmeventd.service")
 
         # Perform a pvscan in contaier
-        openshift_ops.oc_rsh(
-            self.oc_node, pod_name, "pvscan")
+        openshift_ops.oc_rsh(self.oc_node, pod_name, cmd_pvscan)
 
         # Get heketi node to add new device
         heketi_node_list = heketi_ops.heketi_node_list(h_client, h_url)
@@ -401,4 +403,4 @@ class TestHeketiLvmWrapper(baseclass.BaseClass):
         self._check_heketi_and_gluster_pod_after_node_reboot(server_node)
 
         # Perform a pvscan in contaier
-        openshift_ops.oc_rsh(self.oc_node, pod_name, "pvscan")
+        openshift_ops.oc_rsh(self.oc_node, pod_name, cmd_pvscan)

--- a/tests/functional/heketi/test_heketi_volume_operations.py
+++ b/tests/functional/heketi/test_heketi_volume_operations.py
@@ -245,6 +245,7 @@ class TestHeketiVolumeOperations(BaseClass):
     @pytest.mark.tier2
     def test_heketi_volume_create_mutiple_sizes(self):
         """Validate creation of heketi volume with differnt sizes"""
+        prefix = "autotest-{}".format(utils.get_random_str())
         sizes, required_space = [15, 50, 100], 495
         h_node, h_url = self.heketi_client_node, self.heketi_server_url
 
@@ -256,8 +257,8 @@ class TestHeketiVolumeOperations(BaseClass):
 
         # Create volume 3 times, each time different size
         for size in sizes:
-            vol_id = heketi_volume_create(h_node, h_url, size, json=True)['id']
-            self.addCleanup(heketi_volume_delete, h_node, h_url, vol_id)
+            self.create_heketi_volume_with_name_and_wait(
+                "{}-{}".format(prefix, size), size, json=True)
 
     @pytest.mark.tier2
     @podcmd.GlustoPod()

--- a/tests/functional/heketi/test_volume_multi_req.py
+++ b/tests/functional/heketi/test_volume_multi_req.py
@@ -249,7 +249,7 @@ class TestVolumeMultiReq(BaseClass):
             size=2)
         c1.create_pvc(ocp_node)
         self.addCleanup(c1.delete_pvc, ocp_node)
-        c1.update_pvc_info(ocp_node)
+        c1.update_pvc_info(ocp_node, timeout=300)
         # verify volume exists
         self.assertTrue(c1.volumeName)
         c1.update_pv_info(ocp_node)
@@ -269,7 +269,7 @@ class TestVolumeMultiReq(BaseClass):
             size=2)
         c2.create_pvc(ocp_node)
         self.addCleanup(c2.delete_pvc, ocp_node)
-        c2.update_pvc_info(ocp_node)
+        c2.update_pvc_info(ocp_node, timeout=300)
         # verify volume exists
         self.assertTrue(c2.volumeName)
         c2.update_pv_info(ocp_node)
@@ -317,8 +317,8 @@ class TestVolumeMultiReq(BaseClass):
         self.addCleanup(c2.delete_pvc, ocp_node)
 
         # wait for pvcs/volumes to complete
-        c1.update_pvc_info(ocp_node)
-        c2.update_pvc_info(ocp_node)
+        c1.update_pvc_info(ocp_node, timeout=300)
+        c2.update_pvc_info(ocp_node, timeout=300)
         now_vols = _heketi_name_id_map(
             _heketi_vols(ocp_node, self.heketi_server_url))
 
@@ -378,7 +378,7 @@ class TestVolumeMultiReq(BaseClass):
             t.join()
 
         for c in claims:
-            c.update_pvc_info(ocp_node, timeout=120)
+            c.update_pvc_info(ocp_node, timeout=300)
         now_vols = _heketi_name_id_map(
             _heketi_vols(ocp_node, self.heketi_server_url))
         for c in claims:
@@ -417,7 +417,7 @@ class TestVolumeMultiReq(BaseClass):
                     size=2)
                 c.create_pvc(ocp_node)
                 time.sleep(1)
-                c.update_pvc_info(ocp_node, timeout=120)
+                c.update_pvc_info(ocp_node, timeout=300)
                 c.update_pv_info(ocp_node)
                 time.sleep(random.randint(1, 10) * 0.1)
                 c.delete_pvc(ocp_node)
@@ -457,8 +457,8 @@ class TestVolumeMultiReq(BaseClass):
         self.addCleanup(c2.delete_pvc, ocp_node)
 
         # wait for pvcs/volumes to complete
-        c1.update_pvc_info(ocp_node, timeout=120)
-        c2.update_pvc_info(ocp_node, timeout=120)
+        c1.update_pvc_info(ocp_node, timeout=300)
+        c2.update_pvc_info(ocp_node, timeout=300)
 
         # verify first volume exists
         self.assertTrue(c1.volumeName)


### PR DESCRIPTION
Fix issues -
- Add timeouts for long executing commands
- Use baseclass function to create large size heketi volume
- Move TC `test_arbiter_scaled_heketi_and_gluster_volume_mapping' to tier4 as it require to run on large no of volumes
- Resource creation get fails due timeout on some cluster configurations. Increase timeout to get resource in `Bound` state even in small configs