### PR TITLE
[LibFix] Add check for Self-heal & Snapshot Daemon gluster volume state

### DIFF
--- a/openshift-storage-libs/openshiftstoragelibs/baseclass.py
+++ b/openshift-storage-libs/openshiftstoragelibs/baseclass.py
@@ -1401,8 +1401,11 @@ class ScaleUpBaseClass(GlusterBlockBaseClass):
                 for brick_or_shd in status[vol][host].keys():
                     if status[vol][host][brick_or_shd]['status'] != "1":
                         down_bricks += 1
-                    pid = status[vol][host][brick_or_shd]['pid']
-                    pids[pid] += 1
+
+                    if brick_or_shd not in (
+                            "Self-heal Daemon", "Snapshot Daemon"):
+                        pid = status[vol][host][brick_or_shd]['pid']
+                        pids[pid] += 1
 
         # Get Pids which are running more than 250 bricks and raise exception
         exhausted_pids = [pd for pd in pids.keys() if pids[pd] > 250]


### PR DESCRIPTION
**Self-heal Daemon** and **Snapshot Daemon** are not a brick hence should not be included while calculating brick processes. Add check to ignore **Self-heal Daemon** from gluster volume state command.