### PR TITLE
[ConfigFix] Add 'PyYAML==5.4.1' version in 'functional3' tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ commands =
     python3 -m pip install --upgrade pip>=9.0.0 setuptools wheel
     pip3 install \
         pytest>=5.4.2 \
+        pyyaml==5.4.1 \
         simplejson \
         mock \
         rtyaml \


### PR DESCRIPTION
Latest version of PyYAML [> 5.4.1], `yaml.load(f)` is deprecated in favour of `yaml.load(f, Loader=loader)`. This causing below error while using `functional3` tox env
```
File "/usr/local/lib/python3.6/site-packages/glusto/configurable.py", line 215, in _load_yaml
config = yaml.load(configfd)
TypeError: load() missing 1 required positional argument: 'Loader'
```
Refer - https://github.com/yaml/pyyaml/issues/576 