### PR TITLE
[LibFix] Update 'rhel7' image with absolute path

### DIFF
--- a/openshift-storage-libs/openshiftstoragelibs/openshift_ops.py
+++ b/openshift-storage-libs/openshiftstoragelibs/openshift_ops.py
@@ -2101,7 +2101,7 @@ def oc_create_offline_block_volume_expand_job(
             "template": {
                 "spec": {
                     "containers": [{
-                        "image": "rhel7",
+                        "image": "registry.access.redhat.com/rhel7",
                         "imagePullPolicy": "IfNotPresent",
                         "env": [
                             {


### PR DESCRIPTION
Use absolute path in library `oc_create_offline_block_volume_expand_job` to avoid `ImagePullError`