### PR TITLE
[Config] Add new test merker for scaled heketi operations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,4 @@ markers =
     concurrentOps: concurrent file volume operations tests
     concurrentBlockOps: concurrent blockvolume operations tests
     noDelay: tests without operation delay
+    heketiOps: scaled heketi volume operations tests


### PR DESCRIPTION
Add new test marker `heketiOps` in pytest.ini. It is used for scaled heketi volume operation test cases.