### PR TITLE
[Config] Update git repository URL

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,10 +28,10 @@ commands =
         pyvmomi \
         pytest-custom-exit-code \
         prometheus_client>=0.4.2 \
-        git+git://github.com/loadtheaccumulator/glusto.git \
-        "git+git://github.com/gluster/glusto-tests.git#egg=glustolibs-gluster&subdirectory=glustolibs-gluster" \
-        "git+git://github.com/gluster/glusto-tests.git#egg=glustolibs-io&subdirectory=glustolibs-io" \
-        "git+git://github.com/gluster/glusto-tests.git#egg=glustolibs-misc&subdirectory=glustolibs-misc" \
+        git+https://github.com/loadtheaccumulator/glusto.git \
+        "git+https://github.com/gluster/glusto-tests.git#egg=glustolibs-gluster&subdirectory=glustolibs-gluster" \
+        "git+https://github.com/gluster/glusto-tests.git#egg=glustolibs-io&subdirectory=glustolibs-io" \
+        "git+https://github.com/gluster/glusto-tests.git#egg=glustolibs-misc&subdirectory=glustolibs-misc" \
         --editable=file:///{toxinidir}/openshift-storage-libs
     {posargs:bash -c "echo 'No commands have been specified. Exiting.'; exit 1"}
 
@@ -50,10 +50,10 @@ commands =
         pyvmomi \
         pytest-custom-exit-code \
         prometheus_client>=0.4.2 \
-        git+git://github.com/loadtheaccumulator/glusto.git@python3_port4 \
-        "git+git://github.com/gluster/glusto-tests.git#egg=glustolibs-gluster&subdirectory=glustolibs-gluster" \
-        "git+git://github.com/gluster/glusto-tests.git#egg=glustolibs-io&subdirectory=glustolibs-io" \
-        "git+git://github.com/gluster/glusto-tests.git#egg=glustolibs-misc&subdirectory=glustolibs-misc" \
+        git+https://github.com/loadtheaccumulator/glusto.git@python3_port4 \
+        "git+https://github.com/gluster/glusto-tests.git#egg=glustolibs-gluster&subdirectory=glustolibs-gluster" \
+        "git+https://github.com/gluster/glusto-tests.git#egg=glustolibs-io&subdirectory=glustolibs-io" \
+        "git+https://github.com/gluster/glusto-tests.git#egg=glustolibs-misc&subdirectory=glustolibs-misc" \
         --editable=file:///{toxinidir}/openshift-storage-libs
     {posargs:bash -c "echo 'No commands have been specified. Exiting.'; exit 1"}
 


### PR DESCRIPTION
GitHub recently updated git protocol policy to improve security and dropped insecure signature algorithms. It dropped unencrypted `git://` and disabled support for this protocol.

Update `git://` with `https://` to install glusto libraries in tox env.

Refer - https://github.blog/2021-09-01-improving-git-protocol-security-github/